### PR TITLE
[Fluxerbridge] Fix for immediate timeout

### DIFF
--- a/fluxerbridge/fluxerbridge.py
+++ b/fluxerbridge/fluxerbridge.py
@@ -1227,9 +1227,13 @@ class FluxerBridge(commands.Cog):
             return
 
         try:
-            msg = await self.bot.wait_for(
-                "message", check=MessagePredicate.same_context(channel=dm_msg.channel)
-            )
+            while True:
+                msg = await self.bot.wait_for(
+                    "message", check=MessagePredicate.same_context(channel=dm_msg.channel)
+                )
+                if msg.author.id != ctx.author.id:
+                    continue
+                break
         except asyncio.TimeoutError:
             await ctx.author.send("Timed out.")
             return


### PR DESCRIPTION
Found this error when trying to add new bridges. On Fluxer, at least, the bot would get its own message triggering this and immediately fail, but it could even be a message from another cog, so…

This is one fix. Not sure if you have a lib of functions somewhere to catch this and restrict it to only non-self.